### PR TITLE
fix: status tests getting called when calling shlvl

### DIFF
--- a/mpanic.sh
+++ b/mpanic.sh
@@ -778,7 +778,7 @@
 					"pipe") pipe_test_call;;
 					"redirection") redirection_test_call;;
 					"status") status_test_call;;
-					"shlvl") status_test_call;;
+					"shlvl") shlvl_test_call;;
 					"panicm") panic_mandatory_test_call;;
 					"panics") panic_scapes_test_call;;
 					"your") your_test_call;;


### PR DESCRIPTION
Hey Barcelona colleagues! I have seen that "status_test_call" is getting called instead of "shlvl" tests, fixed now :)